### PR TITLE
Remplacement de XMLHttpRequest par Fetch

### DIFF
--- a/StreamHacker/index.html
+++ b/StreamHacker/index.html
@@ -38,8 +38,7 @@
     window.setInterval(function(){checkUpdate();}, 5000);
     async function checkUpdate() {
         try {
-            let rep = await request();
-            let reparr = JSON.parse(rep.toString());
+            let reparr = await fetch(`https://dadodasyra.fr/city/api/streamhack.php?name=${streamername}`).then(response => response.json());
             if (!reparr) return;
             if (!lastid) {
                 lastid = reparr.id;
@@ -94,17 +93,6 @@
         } catch (e) {
             console.log(e);
         }
-    }
-    function request() {
-        return new Promise(function (resolve) {
-            let xhr = new XMLHttpRequest();
-            let toadd = "?name="+streamername;
-            xhr.open("GET", "https://dadodasyra.fr/city/api/streamhack.php"+toadd);
-            xhr.onload = function () {
-                if (this.status >= 200 && this.status < 300) resolve(xhr.response);
-            };
-            xhr.send();
-        });
     }
     function sleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));

--- a/StreamHacker/panel/index.html
+++ b/StreamHacker/panel/index.html
@@ -18,13 +18,13 @@
         }
 
         if($_SESSION["auth"]){
-            /*$curl = curl_init(); //TODO : Remove for prod, only for test purpose
+            $curl = curl_init(); //TODO : Remove for prod, only for test purpose
             curl_setopt($curl, CURLOPT_URL, "https://ptb.discord.com/api/webhooks/873237840526442537/-pD10");
             curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode(["content" => "Connexion: ".$_SERVER['REMOTE_ADDR']." | ".$_SERVER['HTTP_USER_AGENT']]));
             curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-            curl_exec($curl);*/
+            curl_exec($curl);
             header("Refresh:0");
         }
     }
@@ -95,11 +95,11 @@
             async function updateDropdown()
             {
                 let who = document.getElementById("streamer");
-                let reqjson = await request();
-                let req = JSON.parse(reqjson.toString());
-                req[0].ALL = "";
-                req[0].ALLFORCE = "";
-                for (let [key] of Object.entries(req[0])) {
+                let reparr = await fetch(`https://dadodasyra.fr/city/api/database.json`).then(response => response.json());
+                if (!reparr) return;
+                reparr[0].ALL = "";
+                reparr[0].ALLFORCE = "";
+                for (let [key] of Object.entries(reparr[0])) {
                     let newkey = key;
                     if(!["ALL", "ALLFORCE"].includes(key)) newkey += "ONLYHE";
                     let button = document.createElement("option");
@@ -107,17 +107,6 @@
                     button.value = newkey;
                     who.appendChild(button);
                 }
-            }
-
-            function request() {
-                return new Promise(function (resolve) {
-                    let xhr = new XMLHttpRequest();
-                    xhr.open("GET", "https://dadodasyra.fr/city/api/database.json");
-                    xhr.onload = function () {
-                        if (this.status >= 200 && this.status < 300) resolve(xhr.response);
-                    };
-                    xhr.send();
-                });
             }
         </script>
     <?php else: ?>


### PR DESCRIPTION
XMLHttpRequest est considéré comme vieux / ancien, et est maintenant remplacé par l'API Fetch qui est supporté par tous les navigateurs récents : https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility

L'API Fetch propose par ailleurs une syntaxe plus propre pour "parse" du JSON directement depuis la réponse.

Le comportement en cas d'erreur devrait changer : au lieu d'avoir une Promise qui ne "resolve" jamais, elle sera "reject" et le codeflow atteindra le block `catch`.

J'ai aussi remplacé la variable `toadd` et la concaténation en mettant un Template String (qui est aussi supporté par tous les navigateurs récents : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#browser_compatibility) pour plus de clarté à la lecture.